### PR TITLE
Update Manifest Version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Redmine Card Extension",
   "version": "0.1.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "This extension is for connecting Github pull requests to Redmine cards.",
   "icons": {
     "16": "assets/icon-16.png",


### PR DESCRIPTION
In January 2023: Manifest V2 extensions will stop working and won’t run in Chrome, developers may not be able to push updates to them even with enterprise policy.

https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/